### PR TITLE
Support AWS HTTP API by making httpMethod optional.

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ const generateCacheHeaders = (routeSettings, currentHeaders = {}) => {
 };
 
 const shouldAddCachingHeaders = (handler) => {
-    if (ignoreMethods.includes(handler.event.httpMethod.toLowerCase())) {
+    if (ignoreMethods.includes(handler.event.httpMethod?.toLowerCase())) {
         return false;
     }
 


### PR DESCRIPTION
The new HTTP API from AWS is faster and cheaper. In order to support it, we need to make `httpMethod` optional, as it is no longer provided by switching from REST to HTTP API.

Tested using HTTP API.